### PR TITLE
Skip file download when permission denied error happens

### DIFF
--- a/src/main/java/org/embulk/input/sftp/SingleFileProvider.java
+++ b/src/main/java/org/embulk/input/sftp/SingleFileProvider.java
@@ -45,7 +45,7 @@ public class SingleFileProvider
                 return file.getContent().getInputStream();
             }
             catch (FileSystemException ex) {
-                if (++count == maxConnectionRetry) {
+                if (++count == maxConnectionRetry || ex.getMessage().indexOf("Permission denied") > 0) {
                     throw ex;
                 }
                 log.warn("failed to connect sftp server: " + ex.getMessage(), ex);


### PR DESCRIPTION
Force to skip retrying when FileException happens while downloading file and message contains `Permission Denied`.

``` shell
org.embulk.exec.PartialExecutionException: java.lang.RuntimeException: org.apache.commons.vfs2.FileSystemException: Unknown message with code "Permission denied".
    at org.embulk.exec.BulkLoader$LoaderState.buildPartialExecuteException(org/embulk/exec/BulkLoader.java:363)
    at org.embulk.exec.BulkLoader.doRun(org/embulk/exec/BulkLoader.java:572)
    at org.embulk.exec.BulkLoader.access$000(org/embulk/exec/BulkLoader.java:33)
    at org.embulk.exec.BulkLoader$1.run(org/embulk/exec/BulkLoader.java:374)
    at org.embulk.exec.BulkLoader$1.run(org/embulk/exec/BulkLoader.java:370)
    at org.embulk.spi.Exec.doWith(org/embulk/spi/Exec.java:25)
    at org.embulk.exec.BulkLoader.run(org/embulk/exec/BulkLoader.java:370)
    at org.embulk.EmbulkEmbed.run(org/embulk/EmbulkEmbed.java:180)
    at java.lang.reflect.Method.invoke(java/lang/reflect/Method.java:497)
    at RUBY.run(/Users/satoshi/.embulk/bin/embulk!/embulk/runner.rb:84)
    at RUBY.run(/Users/satoshi/.embulk/bin/embulk!/embulk/command/embulk_run.rb:306)
    at RUBY.<top>(/Users/satoshi/.embulk/bin/embulk!/embulk/command/embulk_main.rb:2)
```
