### PR TITLE
[Fix bugs] Plugin throws ClassNotFoundException with EmbulkEmbed

### DIFF
--- a/src/main/java/org/embulk/input/sftp/SftpFileInput.java
+++ b/src/main/java/org/embulk/input/sftp/SftpFileInput.java
@@ -56,6 +56,7 @@ public class SftpFileInput
         }
 
         StandardFileSystemManager manager = new StandardFileSystemManager();
+        manager.setClassLoader(SftpFileInput.class.getClassLoader());
         try {
             manager.init();
         }

--- a/src/test/java/org/embulk/input/sftp/TestSftpFileInputPlugin.java
+++ b/src/test/java/org/embulk/input/sftp/TestSftpFileInputPlugin.java
@@ -388,6 +388,7 @@ public class TestSftpFileInputPlugin
         while (true) {
             try {
                 StandardFileSystemManager manager = new StandardFileSystemManager();
+                manager.setClassLoader(TestSftpFileInputPlugin.class.getClassLoader());
                 manager.init();
 
                 FileObject localFile = manager.resolveFile(localPath);


### PR DESCRIPTION
I found that plugin throws `java.lang.ClassNotFoundException: org.apache.commons.vfs2.provider.local.DefaultLocalFileProvider` and I fixed it.
This error happens only at an environment that are using EmbulkEmbed.
