### PR TITLE
Use RetryExecutor when listing files and getting files

### DIFF
--- a/src/main/java/org/embulk/input/sftp/SingleFileProvider.java
+++ b/src/main/java/org/embulk/input/sftp/SingleFileProvider.java
@@ -1,15 +1,20 @@
 package org.embulk.input.sftp;
 
+import com.google.common.base.Throwables;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemException;
 import org.apache.commons.vfs2.FileSystemOptions;
 import org.apache.commons.vfs2.impl.StandardFileSystemManager;
 import org.embulk.spi.Exec;
 import org.embulk.spi.util.InputStreamFileInput;
+import org.embulk.spi.util.RetryExecutor.RetryGiveupException;
+import org.embulk.spi.util.RetryExecutor.Retryable;
 import org.slf4j.Logger;
+import static org.embulk.spi.util.RetryExecutor.retryExecutor;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InterruptedIOException;
 import java.util.Iterator;
 
 public class SingleFileProvider
@@ -37,33 +42,58 @@ public class SingleFileProvider
             return null;
         }
         opened = true;
-        String key = iterator.next();
+        final String key = iterator.next();
 
-        int count = 0;
-        while (true) {
-            try {
-                FileObject file = manager.resolveFile(key, fsOptions);
-                log.info("Starting to download file {}", key);
+        try {
+            return retryExecutor()
+                    .withRetryLimit(maxConnectionRetry)
+                    .withInitialRetryWait(500)
+                    .withMaxRetryWait(30 * 1000)
+                    .runInterruptible(new Retryable<InputStream>() {
+                        @Override
+                        public InputStream call() throws FileSystemException
+                        {
+                            log.info("Starting to download file {}", key);
+                            FileObject file = manager.resolveFile(key, fsOptions);
+                            return file.getContent().getInputStream();
+                        }
 
-                return file.getContent().getInputStream();
-            }
-            catch (FileSystemException ex) {
-                if (++count == maxConnectionRetry || ex.getMessage().indexOf("Permission denied") > 0) {
-                    throw ex;
-                }
-                log.warn("failed to connect sftp server: " + ex.getMessage(), ex);
+                        @Override
+                        public boolean isRetryableException(Exception exception)
+                        {
+                            return true;
+                        }
 
-                try {
-                    long sleepTime = ((long) Math.pow(2, count) * 1000);
-                    log.warn("sleep in next connection retry: {} milliseconds", sleepTime);
-                    Thread.sleep(sleepTime); // milliseconds
-                }
-                catch (InterruptedException ex2) {
-                    // Ignore this exception because this exception is just about `sleep`.
-                    log.warn(ex2.getMessage(), ex2);
-                }
-                log.warn("retrying to connect sftp server: " + count + " times");
-            }
+                        @Override
+                        public void onRetry(Exception exception, int retryCount, int retryLimit, int retryWait)
+                                throws RetryGiveupException
+                        {
+                            if (exception.getMessage().indexOf("Permission denied") > 0) {
+                                log.error("Could not download file due to Permission Denied");
+                                throw new RetryGiveupException(exception);
+                            }
+                            String message = String.format("SFTP GET request failed. Retrying %d/%d after %d seconds. Message: %s",
+                                    retryCount, retryLimit, retryWait / 1000, exception.getMessage());
+                            if (retryCount % 3 == 0) {
+                                log.warn(message, exception);
+                            }
+                            else {
+                                log.warn(message);
+                            }
+                        }
+
+                        @Override
+                        public void onGiveup(Exception firstException, Exception lastException)
+                                throws RetryGiveupException
+                        {
+                        }
+                    });
+        }
+        catch (RetryGiveupException ex) {
+            throw Throwables.propagate(ex.getCause());
+        }
+        catch (InterruptedException ex) {
+            throw new InterruptedIOException();
         }
     }
 


### PR DESCRIPTION
Modify retry logic to use `RetryExecutor` that is provied by [embulk-core](https://github.com/embulk/embulk/blob/master/embulk-core/src/main/java/org/embulk/spi/util/RetryExecutor.java)
- `listFilesByPrefix`
- `SingleFileProvider.openNext()`
  - Skip retrying when permission denied error happens
