### PR TITLE
Mask password in the log

### DIFF
--- a/src/main/java/org/embulk/input/sftp/FileList.java
+++ b/src/main/java/org/embulk/input/sftp/FileList.java
@@ -158,7 +158,6 @@ public class FileList
 
             int index = entries.size();
             entries.add(new Entry(index, size));
-            log.info("add file to the request list: {}", path);
 
             byte[] data = path.getBytes(StandardCharsets.UTF_8);
             castBuffer.putInt(0, data.length);

--- a/src/main/java/org/embulk/input/sftp/SftpFileInput.java
+++ b/src/main/java/org/embulk/input/sftp/SftpFileInput.java
@@ -107,6 +107,7 @@ public class SftpFileInput
                 if (proxy.getHost().isPresent()) {
                     builder.setProxyHost(fsOptions, proxy.getHost().get());
                     builder.setProxyPort(fsOptions, proxy.getPort());
+                    log.info("Using proxy {}:{} proxy_type:{}", proxy.getHost().get(), proxy.getPort(), proxy.getType().toString());
                 }
 
                 if (proxy.getUser().isPresent()) {
@@ -132,7 +133,9 @@ public class SftpFileInput
     public static String getSftpFileUri(PluginTask task, String path)
     {
         try {
-            return new URI("sftp", initializeUserInfo(task), task.getHost(), task.getPort(), path, null, null).toString();
+            String uri = new URI("sftp", initializeUserInfo(task), task.getHost(), task.getPort(), path, null, null).toString();
+            log.info("Connecting to sftp://{}:***@{}:{}/", task.getUser(), task.getHost(), task.getPort());
+            return uri;
         }
         catch (URISyntaxException ex) {
             throw new ConfigException(ex);

--- a/src/main/java/org/embulk/input/sftp/SingleFileProvider.java
+++ b/src/main/java/org/embulk/input/sftp/SingleFileProvider.java
@@ -53,7 +53,6 @@ public class SingleFileProvider
                         @Override
                         public InputStream call() throws FileSystemException
                         {
-                            log.info("Starting to download file {}", key);
                             FileObject file = manager.resolveFile(key, fsOptions);
                             return file.getContent().getInputStream();
                         }


### PR DESCRIPTION
When using `user` and `password` options, current plugin shows password string in the log.
I changed the code to show "***" instead of password string.

``` bash
$ embulk run /path/to/config.yml

2016-08-08 11:13:11.308 +0000 [INFO] (0001:transaction): Getting to download file list
2016-08-08 11:13:15.528 +0000 [INFO] (0001:transaction): add file to the request list: sftp://username:password@example.com/home/username/sample_20160805.csv
2016-08-08 11:13:15.676 +0000 [INFO] (0001:transaction): Using local thread executor with max_threads=16 / tasks=1
2016-08-08 11:13:15.854 +0000 [INFO] (0001:transaction): Using time:timestamp column as the data partitioning key
```
