### PR TITLE
Fix listFilesByPrefix() method to list files correctly

### DIFF
--- a/src/main/java/org/embulk/input/sftp/SftpFileInput.java
+++ b/src/main/java/org/embulk/input/sftp/SftpFileInput.java
@@ -246,24 +246,20 @@ public class SftpFileInput
             String remoteBasename = FilenameUtils.getBaseName(fileName);
             if (remoteBasename.startsWith(basename)) {
                 if (lastKey != null && !isMatchLastKey) {
-                    if (!fileName.equals(lastKey)) {
-                        return;
-                    }
-                    else {
+                    if (fileName.equals(lastKey)) {
                         isMatchLastKey = true;
                     }
+                    return;
                 }
                 builder.add(fileName, fileSize);
             }
         }
         else {
             if (lastKey != null && !isMatchLastKey) {
-                if (!fileName.equals(lastKey)) {
-                    return;
-                }
-                else {
+                if (fileName.equals(lastKey)) {
                     isMatchLastKey = true;
                 }
+                return;
             }
             builder.add(fileName, fileSize);
         }

--- a/src/main/java/org/embulk/input/sftp/SftpFileInput.java
+++ b/src/main/java/org/embulk/input/sftp/SftpFileInput.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Arrays;
 
 public class SftpFileInput
         extends InputStreamFileInput
@@ -183,7 +184,9 @@ public class SftpFileInput
                             FileObject files = manager.resolveFile(getSftpFileUri(task, task.getPathPrefix()), fsOptions);
                             String basename = FilenameUtils.getBaseName(task.getPathPrefix());
                             if (files.isFolder()) {
-                                for (FileObject f : files.getChildren()) {
+                                FileObject[] children = files.getChildren();
+                                Arrays.sort(children);
+                                for (FileObject f : children) {
                                     if (f.isFile()) {
                                         addFileToList(builder, f.toString(), f.getContent().getSize(), "", lastKey);
                                     }
@@ -191,7 +194,9 @@ public class SftpFileInput
                             }
                             else {
                                 FileObject parent = files.getParent();
-                                for (FileObject f : parent.getChildren()) {
+                                FileObject[] children = parent.getChildren();
+                                Arrays.sort(children);
+                                for (FileObject f : children) {
                                     if (f.isFile()) {
                                         addFileToList(builder, f.toString(), f.getContent().getSize(), basename, lastKey);
                                     }


### PR DESCRIPTION
I found 2 problems with v0.1.2
## Order of file list

Current implementation returns non sorted file list.
This problem came from `FileObject.getChildren()` method returns [un-ordered array](https://commons.apache.org/proper/commons-vfs/apidocs/org/apache/commons/vfs2/FileObject.html#getChildren%28%29).

Other Embulk input plugin also doesn't guarantee filelist order, but usually returns alphanumeric sorted array because library usuary returns them.

**expected**:
- sample_01.csv
- sample_02.csv
- sample_03.csv

**actual**:
- sample_02.csv
- sample_03.csv
- sample_01.csv

I fixed to return ordered Array.
## Handling of last_path

If plugin get listed data...
- sample_01.csv
- sample_02.csv
- sample_03.csv

And when we set `sample_03.csv` as last_path, plugin returns contents of `sample_03.csv`.
This behavior is different from other Embulk input plugin.
- last_path: sample_01.csv
  - expected: sample_02.csv, sample_03.csv
  - actual: sample_01.csv, sample_02.csv, sample_03.csv
- last_path: sample_03.csv
  - expected: No data was returned
  - actual: sample_03.csv

I fixed this problem.
