### PR TITLE
Fix last_path generation logic

### DIFF
--- a/src/main/java/org/embulk/input/sftp/SftpFileInputPlugin.java
+++ b/src/main/java/org/embulk/input/sftp/SftpFileInputPlugin.java
@@ -30,11 +30,15 @@ public class SftpFileInputPlugin
                              FileInputPlugin.Control control)
     {
         PluginTask task = taskSource.loadTask(PluginTask.class);
+        String lastPath = null;
+        if (task.getIncremental()) {
+            lastPath = SftpFileInput.getRelativePath(task, task.getFiles().getLastPath(task.getLastPath()));
+        }
         control.run(taskSource, taskCount);
 
         ConfigDiff configDiff = Exec.newConfigDiff();
-        if (task.getIncremental()) {
-            configDiff.set("last_path", SftpFileInput.getRelativePath(task.getFiles().getLastPath(task.getLastPath())));
+        if (task.getIncremental() && lastPath != null) {
+            configDiff.set("last_path", lastPath);
         }
 
         return configDiff;

--- a/src/test/java/org/embulk/input/sftp/TestSftpFileInputPlugin.java
+++ b/src/test/java/org/embulk/input/sftp/TestSftpFileInputPlugin.java
@@ -227,7 +227,7 @@ public class TestSftpFileInputPlugin
 
         assertEquals(expected.get(0), actual.get(0));
         assertEquals(expected.get(1), actual.get(1));
-        assertEquals(SftpFileInput.getRelativePath(Optional.of(expected.get(1).get(0))), configDiff.get(String.class, "last_path"));
+        assertEquals(SftpFileInput.getRelativePath(task, Optional.of(expected.get(1).get(0))), configDiff.get(String.class, "last_path"));
     }
 
     @Test
@@ -371,6 +371,23 @@ public class TestSftpFileInputPlugin
 
         ProxyTask.ProxyType.setProxyType(builder, fsOptions, ProxyTask.ProxyType.STREAM);
         assertEquals(SftpFileSystemConfigBuilder.PROXY_STREAM, builder.getProxyType(fsOptions));
+    }
+
+    @Test
+    public void testGetRelativePath()
+    {
+        ConfigSource conf = config();
+        String expected = "/path/to/sample.csv";
+
+        conf.set("password", "ABCDE");
+        PluginTask task = config.loadConfig(PluginTask.class);
+        String uri = SftpFileInput.getSftpFileUri(task, "/path/to/sample.csv");
+        assertEquals(expected, SftpFileInput.getRelativePath(task, Optional.of(uri)));
+
+        conf.set("password", "ABCD#$¥!%'\"@?<>\\&/_^~|-=+-,{}[]()");
+        task = config.loadConfig(PluginTask.class);
+        uri = SftpFileInput.getSftpFileUri(task, "/path/to/sample.csv");
+        assertEquals(expected, SftpFileInput.getRelativePath(task, Optional.of(uri)));
     }
 
     private SshServer createSshServer(String host, int port, final String sshUsername, final String sshPassword)


### PR DESCRIPTION
I found that current implementation fails to generate `last_path` with following condition.
- auth method is password
- password contains special characters like '#'
