### PR TITLE
Use second as timetout setting instead of milli second

### DIFF
--- a/src/main/java/org/embulk/input/sftp/SftpFileInput.java
+++ b/src/main/java/org/embulk/input/sftp/SftpFileInput.java
@@ -88,7 +88,7 @@ public class SftpFileInput
         try {
             SftpFileSystemConfigBuilder builder = SftpFileSystemConfigBuilder.getInstance();
             builder.setUserDirIsRoot(fsOptions, task.getUserDirIsRoot());
-            builder.setTimeout(fsOptions, task.getSftpConnectionTimeout());
+            builder.setTimeout(fsOptions, task.getSftpConnectionTimeout() * 1000);
             builder.setStrictHostKeyChecking(fsOptions, "no");
 
             if (task.getSecretKeyFile().isPresent()) {


### PR DESCRIPTION
Current code intend to use 600 sec as default timeout value.
But actual behavior is 600 msec.

Second parameter of SftpFileSystemConfigBuilder.setTimeout() allows msec, it's not a sec.

> SftpFileSystemConfigBuilder.setTimeout(FileSystemOptions opts, Integer timeout)
> - Parameters:
>   - opts - The FileSystem options.
>   - timeout - The timeout in milliseconds.

https://commons.apache.org/proper/commons-vfs/apidocs/org/apache/commons/vfs2/provider/sftp/SftpFileSystemConfigBuilder.html#setTimeout
