### PR TITLE
Don't generate last_path by using password when secret_keyfile is set

### DIFF
--- a/src/main/java/org/embulk/input/sftp/SftpFileInput.java
+++ b/src/main/java/org/embulk/input/sftp/SftpFileInput.java
@@ -149,7 +149,7 @@ public class SftpFileInput
             if (!uri.isPresent()) {
                 return null;
             }
-            else if (task.getPassword().isPresent()) {
+            else if (!task.getSecretKeyFile().isPresent() && task.getPassword().isPresent()) {
                 return getRelativePathFromURIwithPassword(task, uri);
             }
             else {


### PR DESCRIPTION
Auth Failure happens when...
- Auth method is Public/Private key pair authentication
- Set both of `password` and `secret_key_file`
