### PR TITLE
Add Bintray settings to build.gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ in:
 
 ```
 $ ./gradlew gem  # -t to watch change of files and rebuild continuously
+$ ./gradlew bintrayUpload # release embulk-input-sftp to Bintray maven repo
 ```
 
 ## Test

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
-    id "com.jfrog.bintray" version "1.1"
+    id "com.jfrog.bintray" version "1.7"
+    id "maven-publish"
     id "com.github.jruby-gradle.base" version "0.1.5"
     id "java"
     id "checkstyle"
@@ -14,6 +15,7 @@ configurations {
     provided
 }
 
+group = "org.embulk.input.sftp"
 version = "0.2.3"
 
 sourceCompatibility = 1.7
@@ -33,12 +35,70 @@ dependencies {
     testCompile "io.netty:netty-all:4.0.34.Final"
 }
 
+javadoc {
+    options {
+        locale = 'en_US'
+        encoding = 'UTF-8'
+    }
+}
+
+// bintray
+bintray {
+    // write at your bintray user name and api key to ~/.gradle/gradle.properties file:
+    user = project.hasProperty('bintray_user') ? bintray_user : ''
+    key = project.hasProperty('bintray_api_key') ? bintray_api_key : ''
+
+    publications = ['bintrayMavenRelease']
+    publish = true
+
+    pkg {
+        userOrg = 'embulk-input-sftp'
+        repo = 'maven'
+        name = project.name
+        desc = 'SFTP file input plugin for Embulk'
+        websiteUrl = 'https://github.com/embulk/embulk-input-sftp'
+        issueTrackerUrl = 'https://github.com/embulk/embulk-input-sftp/issues'
+        vcsUrl = 'https://github.com/embulk/embulk-input-sftp.git'
+        licenses = ['Apache-2.0']
+        labels = ['embulk', 'java']
+        publicDownloadNumbers = true
+
+        version {
+            name = project.version
+        }
+    }
+}
+publishing {
+    publications {
+        bintrayMavenRelease(MavenPublication) {
+            from components.java
+            artifact testsJar
+            artifact sourcesJar
+            artifact javadocJar
+        }
+    }
+}
+
 task classpath(type: Copy, dependsOn: ["jar"]) {
     doFirst { file("classpath").deleteDir() }
     from (configurations.runtime - configurations.provided + files(jar.archivePath))
     into "classpath"
 }
 clean { delete "classpath" }
+
+// add tests/javadoc/source jar tasks as artifacts to be released
+task testsJar(type: Jar, dependsOn: classes) {
+    classifier = 'tests'
+    from sourceSets.test.output
+}
+task sourcesJar(type: Jar, dependsOn: classes) {
+    classifier = 'sources'
+    from sourceSets.main.allSource
+}
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    classifier = 'javadoc'
+    from javadoc.destinationDir
+}
 
 checkstyle {
     configFile = file("${project.rootDir}/config/checkstyle/checkstyle.xml")


### PR DESCRIPTION
There're some SaaS/PaaS cloud services that are using SFTP protocol for input method.
I want to write plugins for these services based on this plugin(want to use this plugin as a library).

This PR is almost same with [Add Bintray settings to build.gradle for embulk-output-sftp](https://github.com/embulk/embulk-output-sftp/pull/32) and I confirmed `./gradlew bintrayUpload` works fine.
https://bintray.com/embulk-input-sftp/maven/embulk-input-sftp