### PR TITLE
fix plugin use prefix basename to compare path

### DIFF
--- a/src/main/java/org/embulk/input/sftp/SftpFileInput.java
+++ b/src/main/java/org/embulk/input/sftp/SftpFileInput.java
@@ -197,7 +197,7 @@ public class SftpFileInput
                             }
 
                             FileObject files = manager.resolveFile(getSftpFileUri(task, task.getPathPrefix()), fsOptions);
-                            String basename = FilenameUtils.getBaseName(task.getPathPrefix());
+
                             if (files.isFolder()) {
                                 //path_prefix is a folder, we add everything in that folder
                                 FileObject[] children = files.getChildren();
@@ -218,9 +218,10 @@ public class SftpFileInput
                                 FileObject parent = files.getParent();
                                 FileObject[] children = parent.getChildren();
                                 Arrays.sort(children);
+                                String fileName = FilenameUtils.getName(task.getPathPrefix());
                                 for (FileObject f : children) {
                                     if (f.isFile()) {
-                                        addFileToList(builder, f.toString(), f.getContent().getSize(), basename, lastKey);
+                                        addFileToList(builder, f.toString(), f.getContent().getSize(), fileName, lastKey);
                                     }
                                 }
                             }

--- a/src/test/java/org/embulk/input/sftp/TestSftpFileInputPlugin.java
+++ b/src/test/java/org/embulk/input/sftp/TestSftpFileInputPlugin.java
@@ -235,6 +235,29 @@ public class TestSftpFileInputPlugin
     }
 
     @Test
+    public void testListFilesWithPathPrefixPointToFile() throws Exception
+    {
+        uploadFile(Resources.getResource("sample_01.csv").getPath(), REMOTE_DIRECTORY + "sample_01.csv", true);
+        ConfigSource configSource = config.deepCopy();
+        configSource.set("path_prefix", REMOTE_DIRECTORY + "not_exist.csv");
+        PluginTask task = configSource.loadConfig(PluginTask.class);
+        FileList actual = (FileList) SftpFileInput.listFilesByPrefix(task);
+        assertEquals(0, actual.getTaskCount());
+    }
+
+    @Test
+    public void testListFilesWithPathPrefix() throws Exception
+    {
+        uploadFile(Resources.getResource("sample_01.csv").getPath(), REMOTE_DIRECTORY + "sample_01.csv", true);
+        ConfigSource configSource = config.deepCopy();
+        configSource.set("path_prefix", REMOTE_DIRECTORY + "sample_01");
+        PluginTask task = configSource.loadConfig(PluginTask.class);
+        FileList actual = (FileList) SftpFileInput.listFilesByPrefix(task);
+        assertEquals(1, actual.getTaskCount());
+        assertEquals(actual.get(0).get(0), "sftp://username:password@127.0.0.1:20022/home/username/unittest/sample_01.csv");
+    }
+
+    @Test
     public void testSftpInputByOpen() throws Exception
     {
         uploadFile(Resources.getResource("sample_01.csv").getPath(), REMOTE_DIRECTORY + "sample_01.csv", true);


### PR DESCRIPTION
SFTP plugin use path prefix base name to scan path. Change to use name instead.