### PR TITLE
Use host addon and set `dist:precise` to avoid Travis CI failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: precise
 language: java
 
 jdk:
@@ -6,5 +7,11 @@ jdk:
   - openjdk7
 
 script:
-  - ./gradlew gem
-  - ./gradlew --info check jacocoTestReport
+  - ./gradlew test
+
+after_success:
+  - ./gradlew jacocoTestReport coveralls
+addons:
+  hosts:
+    - example.com
+  hostname: example.com


### PR DESCRIPTION
Use host addon & Set dist: precise for fixing tests. See the below refs.

ref. https://github.com/embulk/embulk-output-sftp/pull/38