### PR TITLE
Fix non existent last_path in sftp

### DIFF
--- a/src/main/java/org/embulk/input/sftp/SftpFileInput.java
+++ b/src/main/java/org/embulk/input/sftp/SftpFileInput.java
@@ -196,7 +196,12 @@ public class SftpFileInput
                                 FileSystemOptions fsOptions = initializeFsOptions(task);
 
                                 if (task.getLastPath().isPresent() && !task.getLastPath().get().isEmpty()) {
-                                    lastKey = manager.resolveFile(getSftpFileUri(task, task.getLastPath().get()), fsOptions).toString();
+                                    final FileObject remotedLastPath = manager.resolveFile(getSftpFileUri(task, task.getLastPath().get()), fsOptions);
+                                    if(remotedLastPath.exists()) {
+                                        lastKey = remotedLastPath.toString();
+                                    } else {
+                                        log.warn("Failed to load last_path due to non-existence in sftp, skip using last_path");
+                                    }
                                 }
 
                                 FileObject files = manager.resolveFile(getSftpFileUri(task, task.getPathPrefix()), fsOptions);


### PR DESCRIPTION
In the previous version, if the last_past does not exist in sftp server, the plugin can not load any files and will lead the confusion whether folder contains nothing or not.

The fix will resolve the last_path only when it exists in sftp server and warning in case it does not exist.