### PR TITLE
Add validation for "host" and "proxy.host"

### DIFF
--- a/src/main/java/org/embulk/input/sftp/SftpFileInput.java
+++ b/src/main/java/org/embulk/input/sftp/SftpFileInput.java
@@ -3,7 +3,6 @@ package org.embulk.input.sftp;
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
-import com.jcraft.jsch.JSchException;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.vfs2.FileObject;
@@ -263,6 +262,9 @@ public class SftpFileInput
                         @Override
                         public boolean isRetryableException(Exception exception)
                         {
+                            if (exception instanceof ConfigException) {
+                                return false;
+                            }
                             return true;
                         }
 
@@ -286,7 +288,7 @@ public class SftpFileInput
                         {
                             // Generally, Auth fail should be caught and throw ConfigException when first retry. But this library is a bit unstable.
                             // So we throw ConfigException after all retries are completed
-                            if (lastException.getCause().getCause() != null) {
+                            if (lastException.getCause() != null && lastException.getCause().getCause() != null) {
                                 Throwable cause = lastException.getCause().getCause();
                                 if (cause.getMessage().contains("Auth fail")) {
                                     throw new ConfigException(lastException);

--- a/src/main/java/org/embulk/input/sftp/SftpFileInput.java
+++ b/src/main/java/org/embulk/input/sftp/SftpFileInput.java
@@ -138,6 +138,20 @@ public class SftpFileInput
         return fsOptions;
     }
 
+    public static void validateHost(PluginTask task)
+    {
+        if (task.getHost().contains("%s")) {
+            throw new ConfigException("'host' can't contain spaces");
+        }
+        getSftpFileUri(task, "/");
+
+        if (task.getProxy().isPresent() && task.getProxy().get().getHost().isPresent()) {
+            if (task.getProxy().get().getHost().get().contains("%s")) {
+                throw new ConfigException("'proxy.host' can't contains spaces");
+            }
+        }
+    }
+
     public static String getSftpFileUri(PluginTask task, String path)
     {
         try {

--- a/src/main/java/org/embulk/input/sftp/SftpFileInput.java
+++ b/src/main/java/org/embulk/input/sftp/SftpFileInput.java
@@ -160,7 +160,9 @@ public class SftpFileInput
             return uri;
         }
         catch (URISyntaxException ex) {
-            throw new ConfigException(ex);
+            String message = String.format("URISyntaxException was thrown: Illegal character in sftp://%s:******@%s:%s%s",
+                    task.getUser(), task.getHost(), task.getPort(), path);
+            throw new ConfigException(message);
         }
     }
 

--- a/src/main/java/org/embulk/input/sftp/SftpFileInputPlugin.java
+++ b/src/main/java/org/embulk/input/sftp/SftpFileInputPlugin.java
@@ -17,6 +17,7 @@ public class SftpFileInputPlugin
     public ConfigDiff transaction(ConfigSource config, FileInputPlugin.Control control)
     {
         PluginTask task = config.loadConfig(PluginTask.class);
+        SftpFileInput.validateHost(task);
 
         // list files recursively
         task.setFiles(SftpFileInput.listFilesByPrefix(task));

--- a/src/test/java/org/embulk/input/sftp/TestSftpFileInputPlugin.java
+++ b/src/test/java/org/embulk/input/sftp/TestSftpFileInputPlugin.java
@@ -162,6 +162,20 @@ public class TestSftpFileInputPlugin
         runner.transaction(config, new Control());
     }
 
+    @Test(expected = ConfigException.class)
+    public void checkDefaultValuesHostIsInvalid()
+    {
+        ConfigSource config = Exec.newConfigSource()
+                .set("host", HOST + " ")
+                .set("user", null)
+                .set("password", PASSWORD)
+                .set("path_prefix", "")
+                .set("last_path", "")
+                .set("parser", parserConfig(schemaConfig()));
+
+        runner.transaction(config, new Control());
+    }
+
     @Test
     public void testResume()
     {


### PR DESCRIPTION
This PR added validation for `host` and `proxy.host`. Almost same with https://github.com/embulk/embulk-output-sftp/pull/48
Plugin doesn't check if these values contains empty chars or not.

And also fixed related 2 problems
* Plugin shows raw password in log when `java.net.URISyntaxException` is thrown
* Plugin try to retry ConfigException