### PR TITLE
Only support Java8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,8 +18,8 @@ configurations {
 group = "org.embulk.input.sftp"
 version = "0.2.12"
 
-sourceCompatibility = 1.7
-targetCompatibility = 1.7
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 dependencies {
     compile  "org.embulk:embulk-core:0.8.6"


### PR DESCRIPTION
Same with https://github.com/embulk/embulk-input-s3/pull/77

Updated (source|target)Compatibility in build.gradle
.travis.yml update isn't necessary. We have already been checking only with Java8.
https://github.com/embulk/embulk-input-sftp/blob/v0.2.12/.travis.yml