### PR TITLE
Update embulk version and use `java.util.Optional` and `java.util.function.Function`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,14 +22,14 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 dependencies {
-    compile  "org.embulk:embulk-core:0.8.6"
-    provided "org.embulk:embulk-core:0.8.6"
+    compile  "org.embulk:embulk-core:0.9.11"
+    provided "org.embulk:embulk-core:0.9.11"
     compile "org.apache.commons:commons-vfs2:2.2"
     compile "commons-io:commons-io:2.6"
     compile "com.jcraft:jsch:0.1.54"
     testCompile "junit:junit:4.+"
-    testCompile "org.embulk:embulk-core:0.8.6:tests"
-    testCompile "org.embulk:embulk-standards:0.8.6"
+    testCompile "org.embulk:embulk-core:0.9.11:tests"
+    testCompile "org.embulk:embulk-standards:0.9.11"
     testCompile "org.apache.sshd:apache-sshd:1.1.0"
     testCompile "org.littleshoot:littleproxy:1.1.0-beta1"
     testCompile "io.netty:netty-all:4.0.34.Final"

--- a/src/main/java/org/embulk/input/sftp/FileList.java
+++ b/src/main/java/org/embulk/input/sftp/FileList.java
@@ -3,7 +3,6 @@ package org.embulk.input.sftp;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
@@ -24,6 +23,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
@@ -181,7 +181,7 @@ public class FileList
             catch (IOException ex) {
                 throw Throwables.propagate(ex);
             }
-            return new FileList(binary.toByteArray(), getSplits(entries), Optional.fromNullable(last));
+            return new FileList(binary.toByteArray(), getSplits(entries), Optional.ofNullable(last));
         }
 
         private List<List<Entry>> getSplits(List<Entry> all)

--- a/src/main/java/org/embulk/input/sftp/PluginTask.java
+++ b/src/main/java/org/embulk/input/sftp/PluginTask.java
@@ -1,12 +1,13 @@
 package org.embulk.input.sftp;
 
-import com.google.common.base.Optional;
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
 import org.embulk.config.ConfigInject;
 import org.embulk.config.Task;
 import org.embulk.spi.BufferAllocator;
 import org.embulk.spi.unit.LocalFile;
+
+import java.util.Optional;
 
 public interface PluginTask
         extends Task, FileList.Task

--- a/src/main/java/org/embulk/input/sftp/ProxyTask.java
+++ b/src/main/java/org/embulk/input/sftp/ProxyTask.java
@@ -2,7 +2,6 @@ package org.embulk.input.sftp;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-import com.google.common.base.Optional;
 import org.apache.commons.vfs2.FileSystemOptions;
 import org.apache.commons.vfs2.provider.sftp.SftpFileSystemConfigBuilder;
 import org.embulk.config.Config;
@@ -11,6 +10,7 @@ import org.embulk.config.ConfigException;
 import org.embulk.config.Task;
 
 import java.util.Locale;
+import java.util.Optional;
 
 interface ProxyTask
         extends Task

--- a/src/main/java/org/embulk/input/sftp/SftpFileInput.java
+++ b/src/main/java/org/embulk/input/sftp/SftpFileInput.java
@@ -104,7 +104,7 @@ public class SftpFileInput
                         task.getSecretKeyPassphrase().getBytes()
                 );
                 builder.setIdentityInfo(fsOptions, identityInfo);
-                log.info("set identity: {}", task.getSecretKeyFile().get());
+                log.info("set identity: {}", task.getSecretKeyFile().get().getPath());
             }
 
             if (task.getProxy().isPresent()) {

--- a/src/main/java/org/embulk/input/sftp/SftpFileInput.java
+++ b/src/main/java/org/embulk/input/sftp/SftpFileInput.java
@@ -1,7 +1,5 @@
 package org.embulk.input.sftp;
 
-import com.google.common.base.Function;
-import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -29,6 +27,8 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
+import java.util.Optional;
+import java.util.function.Function;
 import java.util.regex.Pattern;
 
 import static org.embulk.spi.util.RetryExecutor.retryExecutor;
@@ -100,7 +100,7 @@ public class SftpFileInput
 
             if (task.getSecretKeyFile().isPresent()) {
                 IdentityInfo identityInfo = new IdentityInfo(
-                        new File((task.getSecretKeyFile().transform(localFileToPathString()).get())),
+                        new File((task.getSecretKeyFile().map(localFileToPathString()).get())),
                         task.getSecretKeyPassphrase().getBytes()
                 );
                 builder.setIdentityInfo(fsOptions, identityInfo);

--- a/src/test/java/org/embulk/input/sftp/TestSftpFileInputPlugin.java
+++ b/src/test/java/org/embulk/input/sftp/TestSftpFileInputPlugin.java
@@ -1,6 +1,5 @@
 package org.embulk.input.sftp;
 
-import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -54,6 +53,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+
+import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;


### PR DESCRIPTION
* Update Embulk version from 0.8.6 to 0.9.11
* Use `java.util.Optional` and `java.util.function.Function` instead of `com.google.common.base.Optional` and `com.google.common.base.Function`
  * Recent version of Embulk use `java.util.Optional`
* minor fix for logging - show key file path instead of unclear message