### PR TITLE
Hide password in log when parse failure happens

### DIFF
--- a/src/main/java/org/embulk/input/sftp/SingleFileProvider.java
+++ b/src/main/java/org/embulk/input/sftp/SingleFileProvider.java
@@ -55,7 +55,7 @@ public class SingleFileProvider
                         {
                             FileObject file = manager.resolveFile(key, fsOptions);
                             return new InputStreamWithHints(
-                                    file.getContent().getInputStream(), key);
+                                    file.getContent().getInputStream(), file.getPublicURIString());
                         }
 
                         @Override


### PR DESCRIPTION
Follow up for #37 
I noticed SFTP(SSH) password is shown in log.
This should be hidden.

* Before
```
Skipped line sftp://ec2-user:passw0rd@123.45.67.89/path/to/file.csv:4 (java.lang.NumberFormatException: For input string: "abcdefghij"
```

* After
```
2019-01-07 17:56:49.195 +0900 [WARN] (0020:task-0002): Skipped line sftp://ec2-user:***@123.45.67.89/path/to/file.csv:5 (java.lang.NumberFormatException: For input string: " For input string: "abcdefghij"
```