### PR TITLE
Do not retry when "Connection refused" is returned and throw ConfigException 

### DIFF
--- a/src/main/java/org/embulk/input/sftp/SftpFileInput.java
+++ b/src/main/java/org/embulk/input/sftp/SftpFileInput.java
@@ -266,8 +266,10 @@ public class SftpFileInput
                         {
                             if (exception.getCause() != null && exception.getCause().getCause() != null) {
                                 Throwable cause = exception.getCause().getCause();
-                                if (cause.getMessage() != null && cause.getMessage().contains("Auth fail")) {
-                                    throw new ConfigException(exception);
+                                if (cause.getMessage() != null) {
+                                    if (cause.getMessage().contains("Auth fail") || cause.getMessage().contains("Connection refused")) {
+                                        throw new ConfigException(exception);
+                                    }
                                 }
                             }
                             if (exception instanceof ConfigException) {


### PR DESCRIPTION
Similar with #33 

In #33 I changed the code not to retry Exception which message contains "Auth Fail" because this type of Exception isn't retryable.

As same as #33, "Connection refused" is also a non retryable Exception.
I think this plugin should not retry and throw ConfigException immediately.