### PR TITLE
Update commons vfs2 latest version to fix timeout setting not working

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id "java"
     id "checkstyle"
     id "jacoco"
-    id "org.embulk.embulk-plugins" version "0.4.0"
+    id "org.embulk.embulk-plugins" version "0.4.2"
 }
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id "java"
     id "checkstyle"
     id "jacoco"
-    id "org.embulk.embulk-plugins" version "0.3.0"
+    id "org.embulk.embulk-plugins" version "0.4.0"
 }
 
 repositories {
@@ -13,7 +13,7 @@ repositories {
 }
 
 group = "org.embulk.input.sftp"
-version = "0.3.3"
+version = "0.3.4"
 description = "Reads files stored on remote server using SFTP."
 
 sourceCompatibility = 1.8
@@ -25,7 +25,10 @@ tasks.withType(JavaCompile) {
 
 dependencies {
     compileOnly "org.embulk:embulk-core:0.9.23"
-    compile "org.apache.commons:commons-vfs2:2.2"
+    compile("org.apache.commons:commons-vfs2:2.6.0") {
+        exclude group: "com.fasterxml.jackson.core", module: "jackson-databind"
+        exclude group: "com.fasterxml.jackson.core", module: "jackson-annotations"
+    }
     compile "commons-io:commons-io:2.6"
     compile "com.jcraft:jsch:0.1.55"
 

--- a/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -2,6 +2,9 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.jcraft:jsch:0.1.55
+com.squareup.okhttp:okhttp:2.7.5
+com.squareup.okio:okio:1.6.0
 commons-io:commons-io:2.6
 commons-logging:commons-logging:1.2
-org.apache.commons:commons-vfs2:2.2
+org.apache.commons:commons-vfs2:2.6.0
+org.apache.hadoop:hadoop-hdfs-client:3.2.1

--- a/src/main/java/org/embulk/input/sftp/SftpFileInput.java
+++ b/src/main/java/org/embulk/input/sftp/SftpFileInput.java
@@ -180,13 +180,7 @@ public class SftpFileInput
                 String uriString = uri.get();
                 String scheme = UriParser.extractScheme(uriString);
                 if (StringUtils.isEmpty(scheme)) {
-                    try {
-                        return GenericFileNameParser.getInstance().parseUri(null, null, uriString).getPath();
-                    }
-                    catch (IllegalArgumentException ignoreEx) {
-                        //backward compatible, old version of GenericFileNameParser didn't strictly verify the uri
-                        return uriString;
-                    }
+                    return GenericFileNameParser.getInstance().parseUri(null, null, uriString).getPath();
                 }
                 else if (scheme.equals("sftp")) {
                     return SftpFileNameParser.getInstance().parseUri(null, null, uriString).getPath();

--- a/src/main/java/org/embulk/input/sftp/SftpFileInput.java
+++ b/src/main/java/org/embulk/input/sftp/SftpFileInput.java
@@ -180,7 +180,13 @@ public class SftpFileInput
                 String uriString = uri.get();
                 String scheme = UriParser.extractScheme(uriString);
                 if (StringUtils.isEmpty(scheme)) {
-                    return GenericFileNameParser.getInstance().parseUri(null, null, uriString).getPath();
+                    try {
+                        return GenericFileNameParser.getInstance().parseUri(null, null, uriString).getPath();
+                    }
+                    catch (IllegalArgumentException ignoreEx) {
+                        //backward compatible, old version of GenericFileNameParser didn't strictly verify the uri
+                        return uriString;
+                    }
                 }
                 else if (scheme.equals("sftp")) {
                     return SftpFileNameParser.getInstance().parseUri(null, null, uriString).getPath();

--- a/src/main/java/org/embulk/input/sftp/SingleFileProvider.java
+++ b/src/main/java/org/embulk/input/sftp/SingleFileProvider.java
@@ -11,6 +11,8 @@ import org.embulk.spi.util.InputStreamFileInput.InputStreamWithHints;
 import org.embulk.spi.util.RetryExecutor.RetryGiveupException;
 import org.embulk.spi.util.RetryExecutor.Retryable;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import static org.embulk.spi.util.RetryExecutor.retryExecutor;
 
 import java.io.IOException;
@@ -25,7 +27,7 @@ public class SingleFileProvider
     private final Iterator<String> iterator;
     private final int maxConnectionRetry;
     private boolean opened = false;
-    private final Logger log = Exec.getLogger(SingleFileProvider.class);
+    private final Logger log = LoggerFactory.getLogger(SingleFileProvider.class);
 
     public SingleFileProvider(PluginTask task, int taskIndex, StandardFileSystemManager manager, FileSystemOptions fsOptions)
     {

--- a/src/main/java/org/embulk/input/sftp/SingleFileProvider.java
+++ b/src/main/java/org/embulk/input/sftp/SingleFileProvider.java
@@ -5,7 +5,6 @@ import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemException;
 import org.apache.commons.vfs2.FileSystemOptions;
 import org.apache.commons.vfs2.impl.StandardFileSystemManager;
-import org.embulk.spi.Exec;
 import org.embulk.spi.util.InputStreamFileInput;
 import org.embulk.spi.util.InputStreamFileInput.InputStreamWithHints;
 import org.embulk.spi.util.RetryExecutor.RetryGiveupException;

--- a/src/test/java/org/embulk/input/sftp/TestSftpFileInputPlugin.java
+++ b/src/test/java/org/embulk/input/sftp/TestSftpFileInputPlugin.java
@@ -470,7 +470,7 @@ public class TestSftpFileInputPlugin
     public void testGetRelativePath()
     {
         String expected = "/path/to/sample !@#.csv";
-        String path = "/path/to/sample !@#.csv";
+        String path = "/path/to/sample%20!@#.csv";
         config.loadConfig(PluginTask.class);
         assertEquals(expected, SftpFileInput.getRelativePath(null, Optional.of(path)));
     }


### PR DESCRIPTION
Timeout setting not working in some cases with old version commons-vfs2:2.2

This issue is fixed on the newer versions, This PR to update to newest version commons-vfs2:2.6.0
- update timeout configuration
- replace deprecated logger Exec.getLogger with LoggerFactory.getLogger
- a small change on `getRelativePath` to support backward compatibility