### PR TITLE
Replace commons logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.3.6 - 2021-04-06
+* [maintenance] Replace commons-logging by jcl-over-slf4j
+
 ## 0.3.5 - 2021-02-02
 * [maintenance] Support OpenSsh key
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 group = "org.embulk.input.sftp"
-version = "0.3.5"
+version = "0.3.6"
 description = "Reads files stored on remote server using SFTP."
 
 sourceCompatibility = 1.8
@@ -25,7 +25,12 @@ tasks.withType(JavaCompile) {
 
 dependencies {
     compileOnly "org.embulk:embulk-core:0.9.23"
-    compile "org.apache.commons:commons-vfs2:2.2"
+    compile ("org.apache.commons:commons-vfs2:2.2") {
+        exclude group: "commons-logging", module: "commons-logging"
+    }
+    compile("org.slf4j:jcl-over-slf4j:1.7.12") {
+        exclude group: "org.slf4j", module: "slf4j-api"
+    }
     compile "commons-io:commons-io:2.6"
     compile "com.github.mwiede:jsch:0.1.60"
 

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
         exclude group: "org.slf4j", module: "slf4j-api"
     }
     compile "commons-io:commons-io:2.6"
-    compile "com.github.mwiede:jsch:0.1.60"
+    compile "com.jcraft:jsch:0.1.55"
 
     testCompile "junit:junit:4.13"
     testCompile "org.embulk:embulk-core:0.9.23:tests"

--- a/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.github.mwiede:jsch:0.1.60
+com.jcraft:jsch:0.1.55
 commons-io:commons-io:2.6
 org.apache.commons:commons-vfs2:2.2
 org.slf4j:jcl-over-slf4j:1.7.12

--- a/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -1,0 +1,7 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+com.github.mwiede:jsch:0.1.60
+commons-io:commons-io:2.6
+org.apache.commons:commons-vfs2:2.2
+org.slf4j:jcl-over-slf4j:1.7.12

--- a/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -1,7 +1,0 @@
-# This is a Gradle generated file for dependency locking.
-# Manual edits can break the build and are not advised.
-# This file is expected to be part of source control.
-com.github.mwiede:jsch:0.1.60
-commons-io:commons-io:2.6
-commons-logging:commons-logging:1.2
-org.apache.commons:commons-vfs2:2.2


### PR DESCRIPTION
Last PR: https://github.com/embulk/embulk-input-sftp/pull/47/files
Revert last PR by replace "com.github.mwiede:jsch:0.1.60"  with "com.jcraft:jsch:0.1.55" because algorithm negotiation error. Replace commons-logging by jcl-over-slf4j to add more log info to investigate.