### PR TITLE
Bump up to v0.4.0-SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 group = "org.embulk.input.sftp"
-version = "0.3.6"
+version = "0.4.0-SNAPSHOT"
 description = "Reads files stored on remote server using SFTP."
 
 sourceCompatibility = 1.8


### PR DESCRIPTION
Updating the second digit into `v0.4.0` as it is going to catch up with Embulk API/SPI v0.10 -- expected big change.