### PR TITLE
Change its Maven group to "org.embulk" from "org.embulk.input.sftp"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ repositories {
     jcenter()
 }
 
-group = "org.embulk.input.sftp"
+group = "org.embulk"
 version = "0.4.0-SNAPSHOT"
 description = "Reads files stored on remote server using SFTP."
 


### PR DESCRIPTION
Since other https://github.com/embulk plugins (e.g. https://repo1.maven.org/maven2/org/embulk/embulk-input-s3/) are based on `org.embulk`, changing its group to the same `org.embulk`.