### PR TITLE
Nominate developers in packages

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -122,6 +122,30 @@ publishing {
                 }
 
                 developers {
+                    developer {
+                        name = "Satoshi Akama"
+                        email = "satoshiakama@gmail.com"
+                    }
+                    developer {
+                        name = "Tai Khuu"
+                        email = "khuutantai@gmail.com"
+                    }
+                    developer {
+                        name = "Trung Huynh"
+                        email = "httrung90@gmail.com"
+                    }
+                    developer {
+                        name = "Dai MIKURUBE"
+                        email = "dmikurube@treasure-data.com"
+                    }
+                    developer {
+                        name = "Viet Nguyen"
+                        email = "viet.nguyen@treasure-data.com"
+                    }
+                    developer {
+                        name = "John Luong"
+                        email = "jluong@treasure-data.com"
+                    }
                 }
 
                 scm {


### PR DESCRIPTION
Maven Central needs `<developers>`. Nominating past contributors there.